### PR TITLE
Updated feedback calculation code avoiding indices

### DIFF
--- a/src/main/scala/com/madgag/wordle/FrequencyMap.scala
+++ b/src/main/scala/com/madgag/wordle/FrequencyMap.scala
@@ -1,0 +1,11 @@
+package com.madgag.wordle
+
+type FrequencyMap[T] = Map[T, Int]
+
+extension [T](freqMap: FrequencyMap[T])
+  def increment(t: T): FrequencyMap[T] = freqMap.updated(t, freqMap(t) + 1)
+  def incrementIf(cond: Boolean)(t: T): FrequencyMap[T] = if (cond) increment(t) else freqMap
+
+object FrequencyMap {
+  def empty[T]: FrequencyMap[T] = Map.empty[T, Int].withDefaultValue(0)
+}


### PR DESCRIPTION
This change uses two great improvements from https://github.com/rtyley/wordle-scala/pull/3 (commit https://github.com/rtyley/wordle-scala/commit/5e878b8839d7aa8eedeaf20e0e522633f2b25794) by Janil Caires Garcia Junior (@janilcgarcia) in the calculation of `WordFeedback.feedbackFor()`:

* Avoiding letter-indicies, which my original code used excessively! Instead it's possible to use `zip` and judicious `foldLeft`s to accumulate the sequential letter-feedback sequence we need, as Janil demonstrated in #3.
* *Counting* rather than *collecting* letters as we build a frequency-map of letters. My original code was grouping by `identity`, unnecessarily creating new collections of letters, before taking the size of each collection to get the letter frequency (throwing away the collection we'd just unneccessarily created). Counting is better - less computation!

There was a bug in PR https://github.com/rtyley/wordle-scala/pull/3 for cases where the same letter was misplaced more than once (although there wasn't a test case to detect that until commit https://github.com/rtyley/wordle-scala/commit/0eb80d8081d1bbc75816dd0673295d1f8a22eefc!), so I've taken the two ideas above and worked them into this alternative implementation, which has a few other improvements on PR https://github.com/rtyley/wordle-scala/pull/3:

* Rather than requiring 3 scans over the words, this implementation requires only 2, by needing only 1 pass, rather than 2, to construct the frequency map - it discounts correct-letter-pairs as it encounters them, rather than removing them in a second pass.
* My personal taste is that the fold-state here is better represented as a case class rather than a type-aliased tuple: a case class lets you name the fields that are in it, for better self-documenting code, and can have new methods defined on it, which can be a great home for the update-the-state method.
* Using `Queue` rather than `Vector` - this choice was based on [Scala collection performance characteristics](https://docs.scala-lang.org/overviews/collections-2.13/performance-characteristics.html ) ...the `append` operation (which is what we're using mostly) is `C` (constant time) rather than `eC` (effectively constant time, depending on...). `Queue` is also a relatively simple collection class compared to the sophisticated `Vector` (~220 lines-of-code vs ~2200), so I'm slightly biased towards using the simplest thing that works. Truthfully, given that the collections are so small, with just 5 elements, the choice of collection doesn't really affect overall performance significantly!

Additional improvements:

* In commit 33f423f5289754a5b0354997d0cbf92ef5db80ae, introducing `type FrequencyMap[T] = Map[T, Int]` and helpful associated extension methods for incrementing an item's frequency means that some of the complexity of `WordFeedback.feedbackFor()` can be moved out, making the tricky `feedbackFor()` method easier to read!
* In commit 0469c9d9c913bb8cdcad23f3ced26ecf61b4892d, only evaluate if a guess-letter was correct once, rather than twice.